### PR TITLE
Save the model in the folder expected by predict.py

### DIFF
--- a/download_w2v_small.sh
+++ b/download_w2v_small.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 if [ ! -f "fairseq_model/wav2vec_small.pt" ]; then
     mkdir -p fairseq_model
-    wget https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec_small.pt -P fairseq
-    wget https://raw.githubusercontent.com/pytorch/fairseq/main/LICENSE -P fairseq/
+    wget https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec_small.pt -P fairseq_model/
+    wget https://raw.githubusercontent.com/pytorch/fairseq/main/LICENSE -P fairseq_model/
 fi
 
 if [ ! -f "pretrained/ckpt_w2vsmall" ]; then

--- a/download_w2v_small.sh
+++ b/download_w2v_small.sh
@@ -11,5 +11,5 @@ if [ ! -f "pretrained/ckpt_w2vsmall" ]; then
     tar -zxvf ckpt_w2vsmall.tar.gz
     mv ckpt_w2vsmall pretrained/
     rm ckpt_w2vsmall.tar.gz
-    cp fairseq/LICENSE pretrained/
+    cp fairseq_model/LICENSE pretrained/
 fi


### PR DESCRIPTION
The default directory in which predict.py checks for a model is `fairseq_model` and not `fairseq`.

Fix  #2 